### PR TITLE
TIS-47/ruleset executor

### DIFF
--- a/db/migrations/R__seed_data.sql
+++ b/db/migrations/R__seed_data.sql
@@ -1,0 +1,4 @@
+INSERT INTO tis_organization (business_id, name)
+     VALUES ('2942108-7', 'Fintraffic Oy')
+ON CONFLICT (business_id)
+         DO UPDATE SET name = 'Fintraffic Oy';

--- a/db/migrations/V3__validation.sql
+++ b/db/migrations/V3__validation.sql
@@ -30,5 +30,3 @@ CREATE TABLE validation_ruleset
     description      TEXT                        NOT NULL,
     CONSTRAINT fk_validation_ruleset_owner_id FOREIGN KEY (owner_id) REFERENCES tis_organization (id) ON DELETE CASCADE
 );
-
-INSERT INTO tis_organization (business_id, name) VALUES ('2942108-7', 'Fintraffic Oy');


### PR DESCRIPTION
Make business id unique to avoid creating ambiguous organizations.