### PR TITLE
remove unnecessary JDBC drivers and other utilities from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,10 @@ FROM flyway/flyway:9
 
 COPY --chown=flyway:flyway db/migrations /flyway/sql
 COPY --chown=flyway:flyway db/flyway.conf /flyway/conf/flyway.conf
+### remove additional JDBC drivers and other unused tools to reduce image size and security alerts
+# keep only postgresql driver
+RUN find /flyway/drivers -type f \! -name 'postgresql-*.jar' -delete
+# remove Azure AD support
+RUN rm -rf /flyway/lib/aad
+# remove Oracle Wallet
+RUN rm -rf /flyway/lib/oracle_wallet


### PR DESCRIPTION
Testing out if we can simply delete some extra files from the image to make things cleaner to run.