### PR TITLE
restore old rules for backwards compatability

### DIFF
--- a/db/migrations/R__seed_data.sql
+++ b/db/migrations/R__seed_data.sql
@@ -51,6 +51,13 @@ BEGIN
 END
 $$;
 
+-- NOTE: If migrating to new replacement rules, keep old ones and set them as SPECIFIC instead of simply deleting the row!
+SELECT upsert_ruleset('2942108-7', 'gtfs', 'gtfs.canonical.v4_0_0', 'Legacy Canonical GTFS Validator by MobilityData (v4.0.0)', 'validation_syntax', 'specific', ARRAY ['prepare.download', 'validate']);
+SELECT upsert_ruleset('2942108-7', 'gtfs', 'gtfs.canonical.v4_1_0', 'Legacy Canonical GTFS Validator by MobilityData (v4.1.0)', 'validation_syntax', 'specific', ARRAY ['prepare.download', 'validate']);
+SELECT upsert_ruleset('2942108-7', 'netex', 'netex.entur.v1_0_1', 'Legacy NeTEx Validator by Entur, version v1.0.1', 'validation_syntax', 'specific', ARRAY ['prepare.download', 'validate']);
+SELECT upsert_ruleset('2942108-7', 'netex', 'netex2gtfs.entur.v2_0_6', 'Legacy NeTEx to GTFS Converter by Entur, version v2.0.6', 'validation_syntax', 'specific', ARRAY ['prepare.download', 'validate']);
+SELECT upsert_ruleset('2942108-7', 'gtfs', 'gtfs2netex.fintraffic.v1_0_0', 'Legacy GTFS to NeTEx Converter by Fintraffic, version v1.12.0', 'validation_syntax', 'specific', ARRAY ['prepare.download', 'validate']);
+-- currently available latest&greatest rulesets
 SELECT upsert_ruleset('2942108-7', 'gtfs', 'gtfs.canonical', 'Canonical GTFS Validator by MobilityData', 'validation_syntax', 'generic', ARRAY ['prepare.download', 'validate']);
 SELECT upsert_ruleset('2942108-7', 'netex', 'netex.entur', 'NeTEx Validator by Entur', 'validation_syntax', 'generic', ARRAY ['prepare.download', 'validate']);
 SELECT upsert_ruleset('2942108-7', 'netex', 'netex2gtfs.entur', 'NeTEx to GTFS Converter by Entur', 'conversion_syntax', 'generic', ARRAY ['prepare.download', 'prepare.stopsAndQuays', 'netex.entur', 'convert']);


### PR DESCRIPTION
Removing these needs database content purge, which we'll get back to in TIS-193