### PR TITLE
TIS-707/override_error_as_warning

### DIFF
--- a/db/migrations/R__seed_data.sql
+++ b/db/migrations/R__seed_data.sql
@@ -106,7 +106,7 @@ $$;
 SELECT upsert_overrides((SELECT id FROM ruleset WHERE identifying_name = 'gtfs.canonical'),
                         ARRAY [('invalid_url', 'WARNING'),('runtime_exception_in_validator_error', 'WARNING'),
                             ('i_o_error', 'WARNING'), ('runtime_exception_in_loader_error', 'WARNING'), ('thread_execution_error', 'WARNING'),
-                            ('u_r_i_syntax_error', 'WARNING')]::rule_severity[]);
+                            ('u_r_i_syntax_error', 'WARNING'), ('trip_distance_exceeds_shape_distance', 'WARNING')]::rule_severity[]);
 
 -- ## `upsert_feature_flags`
 --


### PR DESCRIPTION
trip_distance_exceeds_shape_distance changed to give warning instead