### PR TITLE
TIS-728/publish only Fintraffic and TRAFICOM feeds by default, and default to false

### DIFF
--- a/db/migrations/V32__publish_false_by_default.sql
+++ b/db/migrations/V32__publish_false_by_default.sql
@@ -1,0 +1,9 @@
+-- Changes publishing to false by default, and enables it only for Fintraffic and TRAFICOM (if they exist) by default
+-- this is to avoid flooding downstream data consumers
+ALTER TABLE company
+    ALTER COLUMN publish SET DEFAULT FALSE;
+UPDATE company
+   SET publish = FALSE;
+UPDATE company
+   SET publish = TRUE
+ WHERE business_id IN ('2942108-7', '2924753-3');


### PR DESCRIPTION
This change is made to avoid flooding downstream data consumers. Over time the publishing will diverge from these.