### PR TITLE
TIS-878 Add roles-column into company table

### DIFF
--- a/db/migrations/V41__add_company_roles.sql
+++ b/db/migrations/V41__add_company_roles.sql
@@ -3,6 +3,9 @@ ALTER TABLE company
     ADD COLUMN IF NOT EXISTS roles TEXT[] DEFAULT '{"operator"}';
 
 -- # add authority role to existing authorities
-UPDATE company SET roles = array_append(roles, 'authority') WHERE id IN (
-    SELECT DISTINCT partner_a_id FROM partnership WHERE partnership.type = 'authority-provider'
-    ) AND NOT company.roles @> ARRAY['authority'];
+UPDATE company
+   SET roles = ARRAY_APPEND(roles, 'authority')
+ WHERE id IN (SELECT DISTINCT partner_a_id
+                FROM partnership
+               WHERE partnership.type = 'authority-provider')
+   AND NOT company.roles @> ARRAY ['authority'];

--- a/db/migrations/V41__add_company_roles.sql
+++ b/db/migrations/V41__add_company_roles.sql
@@ -1,0 +1,8 @@
+-- # adding company roles to company
+ALTER TABLE company
+    ADD COLUMN IF NOT EXISTS roles TEXT[] DEFAULT '{"operator"}';
+
+-- # add authority role to existing authorities
+UPDATE company SET roles = array_append(roles, 'authority') WHERE id IN (
+    SELECT DISTINCT partner_a_id FROM partnership WHERE partnership.type = 'authority-provider'
+    ) AND NOT company.roles @> ARRAY['authority'];


### PR DESCRIPTION
# Changes

* Add roles column into company table. Use default "operator" role and assign "authority" role if organisation has an authority partnership